### PR TITLE
fix: auth login fails when one already exists

### DIFF
--- a/commands/auth/init.go
+++ b/commands/auth/init.go
@@ -37,6 +37,17 @@ var (
 				return err
 			}
 
+			// allow user to overwrite existing token
+			if len(token) > 0 {
+				fmt.Println(charm.WarningStyle.Render("Found an auth token, entering a new one will cause an overwrite"))
+				token, err = charm.GetSensitiveInput("Enter your token", "")
+				if err != nil {
+					fmt.Println(charm.ErrorStyle.Render(fmt.Sprintf("error retrieving input %s", err.Error())))
+					return err
+				}
+
+			}
+
 			err = ValidateToken(token)
 			if err != nil {
 				return charm.RenderError("token validation failed:", err)


### PR DESCRIPTION
Previously,  if you attempted to run `qernal auth login` with an exiting token the command would not prompt you to enter a new token. 

This pr enables `auth login` to prompt the user to enter a new token and displays a warning

![image](https://github.com/user-attachments/assets/d20866a7-e157-4518-8844-18f5f9e83d7c)
