### PR TITLE
feat: standardise chaos client parameters

### DIFF
--- a/commands/auth/check.go
+++ b/commands/auth/check.go
@@ -31,7 +31,7 @@ var checkCmd = &cobra.Command{
 
 		// should fail if token is invalid
 		ctx := context.Background()
-		_, err = client.New(ctx, tokenToUse)
+		_, err = client.New(ctx, nil, nil, tokenToUse)
 		if err != nil {
 			return charm.RenderError("❌ invalid token, auth check failed with", err)
 		}

--- a/commands/auth/init.go
+++ b/commands/auth/init.go
@@ -156,7 +156,7 @@ func ValidateToken(token string) error {
 
 	// Make request with token
 	ctx := context.Background()
-	qc, err := client.New(ctx, token)
+	qc, err := client.New(ctx, nil, nil, token)
 	if err != nil {
 		return fmt.Errorf("unable to create qernal client with token, %s", err.Error())
 	}

--- a/commands/projects/create.go
+++ b/commands/projects/create.go
@@ -30,7 +30,7 @@ func NewCreateCmd(printer *utils.Printer) *cobra.Command {
 				return charm.RenderError("unable to retreive qernal token, run qernal auth login if you haven't")
 
 			}
-			qc, err := client.New(ctx, token)
+			qc, err := client.New(ctx, nil, nil, token)
 			if err != nil {
 				return charm.RenderError("", err)
 			}

--- a/commands/projects/delete.go
+++ b/commands/projects/delete.go
@@ -29,7 +29,7 @@ func NewDeleteCmd(printer *utils.Printer) *cobra.Command {
 
 			}
 
-			qc, err := client.New(ctx, token)
+			qc, err := client.New(ctx, nil, nil, token)
 			if err != nil {
 				return charm.RenderError("error creating qernal client", err)
 			}

--- a/commands/projects/list.go
+++ b/commands/projects/list.go
@@ -24,7 +24,7 @@ var ProjectsListCmd = &cobra.Command{
 			return charm.RenderError("unable to retrieive qernal token, run qernal auth login if you haven't")
 		}
 		ctx := context.Background()
-		qc, err := client.New(ctx, token)
+		qc, err := client.New(ctx, nil, nil, token)
 		if err != nil {
 			return charm.RenderError("", err)
 		}

--- a/commands/projects/update.go
+++ b/commands/projects/update.go
@@ -32,7 +32,7 @@ func NewUpdateCmd(printer *utils.Printer) *cobra.Command {
 
 			}
 
-			qc, err := client.New(ctx, token)
+			qc, err := client.New(ctx, nil, nil, token)
 			if err != nil {
 				return charm.RenderError("error creating qernal client", err)
 			}

--- a/commands/secrets/create.go
+++ b/commands/secrets/create.go
@@ -58,7 +58,7 @@ The secret value is read from stdin, allowing for secure input methods.`,
 			return charm.RenderError("unable to retreive qernal token, run qernal auth login if you haven't")
 
 		}
-		qc, err := client.New(ctx, token)
+		qc, err := client.New(ctx, nil, nil, token)
 		if err != nil {
 			return charm.RenderError("", err)
 		}

--- a/commands/secrets/delete.go
+++ b/commands/secrets/delete.go
@@ -20,7 +20,7 @@ var DeleteCmd = &cobra.Command{
 			return charm.RenderError("unable to retreive qernal token, run qernal auth login if you haven't")
 		}
 		ctx := context.Background()
-		qc, err := client.New(ctx, token)
+		qc, err := client.New(ctx, nil, nil, token)
 		if err != nil {
 			return charm.RenderError("", err)
 		}

--- a/commands/secrets/encrypt.go
+++ b/commands/secrets/encrypt.go
@@ -44,7 +44,7 @@ var EncryptCmd = &cobra.Command{
 
 		}
 
-		qc, err := client.New(ctx, token)
+		qc, err := client.New(ctx, nil, nil, token)
 
 		if err != nil {
 			return charm.RenderError("", err)

--- a/commands/secrets/list.go
+++ b/commands/secrets/list.go
@@ -23,7 +23,7 @@ var SecretsListCmd = &cobra.Command{
 			return charm.RenderError("unable to retreive qernal token, run qernal auth login if you haven't")
 		}
 		ctx := context.Background()
-		qc, err := client.New(ctx, token)
+		qc, err := client.New(ctx, nil, nil, token)
 		if err != nil {
 			return charm.RenderError("", err)
 		}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -18,18 +18,26 @@ import (
 	"golang.org/x/crypto/nacl/box"
 )
 
-var (
-	hostHydra = GetEnv("QERNAL_HOST_HYDRA", "https://hydra.qernal.dev")
-	hostChaos = GetEnv("QERNAL_HOST_CHAOS", "https://chaos.qernal.dev")
-)
-
 type QernalAPIClient struct {
 	openapiclient.APIClient
 }
 
-func New(ctx context.Context, token string) (client QernalAPIClient, err error) {
+func New(ctx context.Context, hostHydra, hostChaos *string, token string) (client QernalAPIClient, err error) {
 
-	oauthClient := oauth.NewOauthClient(hostHydra)
+	defaultHostHydra := GetEnv("QERNAL_HOST_HYDRA", "https://hydra.qernal.dev")
+	defaultHostChaos := GetEnv("QERNAL_HOST_CHAOS", "https://chaos.qernal.dev")
+
+	hydra := defaultHostHydra
+	chaos := defaultHostChaos
+
+	if hostHydra != nil {
+		hydra = *hostHydra
+	}
+	if hostChaos != nil {
+		chaos = *hostChaos
+	}
+
+	oauthClient := oauth.NewOauthClient(hydra)
 	err = oauthClient.ExtractClientIDAndClientSecretFromToken(token)
 	if err != nil {
 		return QernalAPIClient{}, err
@@ -43,7 +51,7 @@ func New(ctx context.Context, token string) (client QernalAPIClient, err error) 
 	configuration := &openapiclient.Configuration{
 		Servers: openapiclient.ServerConfigurations{
 			{
-				URL: hostChaos + "/v1",
+				URL: chaos + "/v1",
 			},
 		},
 		DefaultHeader: map[string]string{

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -18,7 +18,7 @@ func CreateOrg() (string, string, error) {
 		return "", "", err
 	}
 	ctx := context.Background()
-	client, err := client.New(ctx, token)
+	client, err := client.New(ctx, nil, nil, token)
 	if err != nil {
 		return "", "", err
 	}
@@ -42,7 +42,7 @@ func DeleteOrg(orgid string) {
 	}
 
 	ctx := context.Background()
-	client, err := client.New(ctx, token)
+	client, err := client.New(ctx, nil, nil, token)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, charm.RenderError("unable to create qernal client", err).Error())
 	}
@@ -59,7 +59,7 @@ func CreateProj(orgid string) (string, string, error) {
 		return "", "", err
 	}
 	ctx := context.Background()
-	client, err := client.New(ctx, token)
+	client, err := client.New(ctx, nil, nil, token)
 	if err != nil {
 		return "", "", err
 	}
@@ -84,7 +84,7 @@ func DeleteProj(projid string) {
 	}
 
 	ctx := context.Background()
-	client, err := client.New(ctx, token)
+	client, err := client.New(ctx, nil, nil, token)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, charm.RenderError("unable to create qernal client", err).Error())
 	}


### PR DESCRIPTION
To reduce the chances that something breaks while we transition to using the cli within the provider. This pr updates the parameters that the new function expects to match the terraform provider