### PR TITLE
fix: encrypt certificate private key, read more than first line on encrypt command

### DIFF
--- a/commands/secrets/create.go
+++ b/commands/secrets/create.go
@@ -28,7 +28,7 @@ func NewCreateCmd(printer *utils.Printer) *cobra.Command {
 		Use:     "create",
 		Aliases: []string{"new"},
 		Short:   "Create a new secret",
-		Long: `Create a new secret in your Qernal project. 
+		Long: `Create a new secret in your Qernal project.
 This command supports creating registry, environment, and certificate secrets.
 The secret value is read from stdin, allowing for secure input methods.`,
 		Example: ` # Create a registry secret
@@ -111,8 +111,8 @@ The secret value is read from stdin, allowing for secure input methods.`,
 				encryptedValue, err := client.EncryptLocalSecret(dek.Payload.SecretMetaResponseDek.Public, plaintext)
 				if err != nil {
 					return charm.RenderError("unable to  encrypt input", err)
-
 				}
+
 				encryptionRef := fmt.Sprintf(`keys/dek/%d`, dek.Revision)
 				_, _, err = qc.SecretsAPI.ProjectsSecretsCreate(ctx, projectID).SecretBody(openapi_chaos_client.SecretBody{
 					Name:       strings.ToUpper(secretName),
@@ -143,6 +143,12 @@ The secret value is read from stdin, allowing for secure input methods.`,
 					return charm.RenderError("Unable to read private key file", err)
 				}
 
+				// encrypt private key
+				privateKeyEncrypted, err := client.EncryptLocalSecret(dek.Payload.SecretMetaResponseDek.Public, strings.TrimSpace(string(privateKeyContent)))
+				if err != nil {
+					return charm.RenderError("unable to private key", err)
+				}
+
 				encryptionRef := fmt.Sprintf(`keys/dek/%d`, dek.Revision)
 				_, _, err = qc.SecretsAPI.ProjectsSecretsCreate(ctx, projectID).SecretBody(openapi_chaos_client.SecretBody{
 					Name:       strings.ToUpper(secretName),
@@ -151,7 +157,7 @@ The secret value is read from stdin, allowing for secure input methods.`,
 					Payload: openapi_chaos_client.SecretCreatePayload{
 						SecretCertificate: &openapi_chaos_client.SecretCertificate{
 							Certificate:      strings.TrimSpace(string(publicKeyContent)),
-							CertificateValue: strings.TrimSpace(string(privateKeyContent)),
+							CertificateValue: privateKeyEncrypted,
 						},
 					},
 				}).Execute()

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -246,6 +246,7 @@ func GetDefaultHost(projid string) (string, error) {
 	return "", errors.New("no default host on project")
 }
 
+// specific to the secret type
 func RandomSecretName() string {
 	const charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	b := make([]byte, 8)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	math_rand "math/rand"
 	"os"
 	"strings"
 
@@ -144,4 +145,14 @@ func (p *Printer) PrintResource(data string) {
 		out = p.resourceOut
 	}
 	fmt.Fprintln(out, data)
+}
+
+// generate random strings of a given length, for testing
+func GenerateRandomString(length int) string {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[math_rand.Intn(len(charset))]
+	}
+	return string(b)
 }


### PR DESCRIPTION
Fixes;

- Encrypt private key for certificate key
- When using encrypt with cat (or stdin with multiple lines) - it would only take the first line